### PR TITLE
nn - fix f22 hard coded backup link

### DIFF
--- a/frontend/src/main/components/Nav/Footer.jsx
+++ b/frontend/src/main/components/Nav/Footer.jsx
@@ -42,7 +42,7 @@ export default function Footer(systemInfo) {
           {!systemInfo.systemInfo && (
             <a
               data-testid="footer-source-code-link"
-              href={"https://github.com/ucsb-cs156-f22/f22-5pm-courses"}
+              href={"https://github.com/ucsb-cs156/proj-courses"}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/frontend/src/tests/components/Nav/Footer.test.jsx
+++ b/frontend/src/tests/components/Nav/Footer.test.jsx
@@ -23,7 +23,7 @@ describe("Footer tests", () => {
     );
     expect(screen.getByTestId("footer-source-code-link")).toHaveAttribute(
       "href",
-      "https://github.com/ucsb-cs156-f22/f22-5pm-courses",
+      "https://github.com/ucsb-cs156/proj-courses",
     );
 
     expect(screen.getByTestId("footer-sticker-link")).toHaveAttribute(


### PR DESCRIPTION
In this PR, we fix the backup value for the GitHub Repo link in the footer of the webpage. It was previously hardcoded to a f22 link. Tests also changed to correspond.

Closes #23